### PR TITLE
Watch errors

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -1,7 +1,8 @@
 {
   "excludeFiles": [
     "node_modules/**",
-    "test-app/dist/**"
+    "test-app/dist/**",
+    "test-app/error"
   ],
   "requireCurlyBraces": [
     "if",

--- a/.jshintignore
+++ b/.jshintignore
@@ -1,2 +1,3 @@
 /node_modules
 /test-app/dist
+/test-app/error

--- a/bin/simplifyify.js
+++ b/bin/simplifyify.js
@@ -66,16 +66,18 @@ program
       })
       .on('error', function(err, fileSet) {
         // Log an error
-        var message = process.env.DEBUG ? err.stack : err.message;
-        if (fileSet && fileSet.entry) {
-          console.error('Error bundling %s\n%s', fileSet.entry, message);
+        if (fileSet && fileSet.entryFile) {
+          console.error('Error bundling %s\n%s', fileSet.entryFile, err);
         }
         else {
+          var message = process.env.DEBUG ? err.stack : err.message;
           console.error(message);
         }
 
         // Exit the app with an error code
-        process.exit(1);
+        if (!program.watch) {
+          process.exit(1);
+        }
       });
   });
 

--- a/lib/write-bundles.js
+++ b/lib/write-bundles.js
@@ -158,6 +158,7 @@ function addCoverageTransform(b) {
 function bundle(b, fileSet) {
   var stream = b.bundle();
   stream.on('end', b.emit.bind(b, 'end'));
+  stream.on('error', b.emit.bind(b, 'error'));
 
   if (fileSet.mapFile) {
     util.ensureFileExists(fileSet.mapFile);

--- a/test-app/error/error.js
+++ b/test-app/error/error.js
@@ -1,0 +1,1 @@
+console.log('this is an error'))

--- a/tests/watch.spec.js
+++ b/tests/watch.spec.js
@@ -216,4 +216,26 @@ describe('simplifyify --watch', function() {
       done();
     }
   });
+
+  it('should report errors', function(done) {
+    this.timeout(10000);
+
+    // Run Watchify
+    var watchify = helper.run('test-app/error/error.js --watch --outfile test-app/dist/error.js', onExit);
+
+    // Check the initial outputs after a few seconds
+    setTimeout(firstCheck, 3000);
+
+    function firstCheck() {
+      watchify.kill();
+    }
+
+    // Verify the final results
+    function onExit(err, stdout, stderr) {
+      expect(stderr).to.be.ok;
+      done();
+    }
+
+  });
+
 });


### PR DESCRIPTION
This tests and fixes #1 

A couple things:
1. If in watch mode, doesn't exit the process. In this way, if you have an error you can see it, then fix it and simplifyify will rebundle, no need to restart the process.
2. I'm logging the full error if the error is created during the bundling process. I don't think hiding that behind a `process.env` flag makes sense. Most developers will need that information to fix the error.
3. I added the test fixture for this to the ignore for linting as it intentionally includes a syntax error.
