### PR TITLE
Allow '*' pattern in standalone option

### DIFF
--- a/lib/expand-globs.js
+++ b/lib/expand-globs.js
@@ -53,6 +53,10 @@ function expandGlobs (globs, options) {
         fileSet.mapFile = fileSet.outputFile + '.map';
       }
 
+      if (options.standalone) {
+        fileSet.standalone = getStandalone(entryFile, pattern, options.standalone);
+      }
+
       matches.push(fileSet);
     });
   });
@@ -131,4 +135,35 @@ function rename (file, baseDir, namePattern) {
 
   let outputDir = path.join(patternDir, relativeDir);                         // dest/subdir
   return path.join(outputDir, fileBaseName + fileExtName);                    // dest/subdir/my-file.min.js
+}
+
+/**
+ * Returns the output file name, based on the the entry file name, the base directory,
+ * and the output path/pattern.
+ *
+ * @param {string} file - The source file path and name (e.g. "my-module/sub-module.js")
+ * @param {string} filePattern - The pattern that got the file (e.g. "my-module/*.js")
+ * @param {string} namePattern - The standalone option pattern (e.g. "my-module-*")
+ * @returns {string} - The UMD standalone module name (e.g. "my-module-sub-module")
+ */
+function getStandalone (file, filePattern, standalonePattern) {
+  let starIndex = filePattern.indexOf('*');
+
+  if (starIndex === -1) {
+    return standalonePattern;
+  }
+
+  let regExpString = Array.from(filePattern)
+    .map((character, index) =>
+      index === starIndex
+        // replace the star with a capture
+        ? '(.*)'
+        // replace the character with a unicode escape
+        : `\\u${`000${character.charCodeAt(0).toString(16)}`.substr(-4)}`)
+    .join('');
+  let globRegExp = new RegExp(regExpString);
+  let match = file.match(globRegExp);
+  let standaloneName = standalonePattern.replace('*', match ? match[1] : '');
+
+  return standaloneName;
 }

--- a/lib/file-set.js
+++ b/lib/file-set.js
@@ -25,4 +25,10 @@ function FileSet () {
    * @type {string}
    */
   this.mapFile = '';
+
+  /**
+   * The UMD standalone module name for a Browserify bundle
+   * @type {string}
+   */
+  this.standalone = '';
 }

--- a/lib/write-bundles.js
+++ b/lib/write-bundles.js
@@ -96,6 +96,7 @@ function createMinifiedBundle (mainFiles, transforms, events, options) {
     // We're creating multiple output files, so append ".min" to the minified file
     minifiedFiles.entryFile = mainFiles.entryFile;
     minifiedFiles.outputFile = util.appendToFileName(mainFiles.outputFile, '.min');
+    minifiedFiles.standalone = mainFiles.standalone;
     if (options.debug) {
       minifiedFiles.mapFile = minifiedFiles.outputFile + '.map';
     }
@@ -127,6 +128,7 @@ function createTestBundle (mainFiles, transforms, events, options) {
     // We're creating multiple output files, so append ".test" to the test file
     testFiles.entryFile = mainFiles.entryFile;
     testFiles.outputFile = util.appendToFileName(mainFiles.outputFile, '.test');
+    testFiles.standalone = mainFiles.standalone;
   }
   else {
     // We're ONLY creating a test file, so this is the main output file
@@ -154,7 +156,7 @@ function newify (fileSet, transforms, events, options) {
   // We always set these options
   let browserifyOptions = {
     entries: fileSet.entryFile,
-    standalone: options.standalone || undefined,
+    standalone: fileSet.standalone || undefined,
     debug: !!fileSet.mapFile,
   };
 

--- a/test/specs/standalone.spec.js
+++ b/test/specs/standalone.spec.js
@@ -151,6 +151,44 @@ describe('simplifyify --standalone', function () {
       });
   });
 
+  it('should create UMD modules with names derived from pattern', function (done) {
+    cli.run('es5/lib/*.js --standalone Fizz.* --outfile es5/dist/',
+      function (err, stdout) {
+        if (err) {
+          return done(err);
+        }
+
+        expect(stdout).to.contain('es5/lib/index.js --> es5/dist/index.js');
+        expect(stdout).to.contain('es5/lib/hello-world.js --> es5/dist/hello-world.js');
+
+        assert.directoryContents('es5/dist', [
+          'index.js',
+          'hello-world.js',
+        ]);
+
+
+        assert.fileContents('es5/dist/index.js', function (contents) {
+          assert.noBanner(contents);
+          assert.hasUmdPreamble(contents);
+          assert.notMinified(contents);
+          assert.noSourceMap(contents);
+          assert.noCoverage(contents);
+          expect(contents).to.match(/\.Fizz = /);
+          expect(contents).to.match(/\.index = /);
+        });
+        assert.fileContents('es5/dist/hello-world.js', function (contents) {
+          assert.noBanner(contents);
+          assert.hasUmdPreamble(contents);
+          assert.notMinified(contents);
+          assert.noSourceMap(contents);
+          assert.noCoverage(contents);
+          expect(contents).to.match(/\.Fizz = /);
+          expect(contents).to.match(/\.helloWorld = /);
+        });
+        done();
+      });
+  });
+
   it('should create a bundle and sourcemap for a universal library', function (done) {
     cli.run('universal-lib/lib/browser.js --outfile universal-lib/dist/universal-lib.js --standalone universal --bundle --debug --minify',
       function (err, stdout) {


### PR DESCRIPTION
    simplifyify 'src/*/index' -s '*' -o dist
    > src/module-a/index.js --> dist/module-a/index.js
    > src/module-b/index.js --> dist/module-b/index.js

UMD names would be "moduleA" and "moduleB" respectively